### PR TITLE
fix: file provisioner does not transfer folders

### DIFF
--- a/builder/lxc/communicator.go
+++ b/builder/lxc/communicator.go
@@ -105,7 +105,7 @@ func (c *LxcAttachCommunicator) UploadDir(dst string, src string, exclude []stri
 	// TODO: remove any file copied if it appears in `exclude`
 	dest := filepath.Join(c.RootFs, dst)
 	log.Printf("Uploading directory '%s' to rootfs '%s'", src, dest)
-	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R %s/. %s", src, dest))
+	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R %s %s", src, dest))
 	if err != nil {
 		return err
 	}

--- a/builder/lxc/communicator.go
+++ b/builder/lxc/communicator.go
@@ -105,6 +105,11 @@ func (c *LxcAttachCommunicator) UploadDir(dst string, src string, exclude []stri
 	// TODO: remove any file copied if it appears in `exclude`
 	dest := filepath.Join(c.RootFs, dst)
 	log.Printf("Uploading directory '%s' to rootfs '%s'", src, dest)
+
+	// Source directories with a trailing slash should only copy the contents of the directory
+	if strings.HasSuffix(src, "/") {
+		src = fmt.Sprintf("%s/.", src)
+	}
 	cpCmd, err := c.CmdWrapper(fmt.Sprintf("cp -R %s %s", src, dest))
 	if err != nil {
 		return err


### PR DESCRIPTION
- The upload directory function currently adds `/.` at the end of the `source` path, which changes the behavior of the `cp`. 
- The change in this PR relies on the user input if the source ends with `/.` we only copy the content of the directory otherwise the while source directory to the destination.

Resolves #31

