### PR TITLE
fix suggested on the original repo to fix permission problem when roo…

### DIFF
--- a/builder/lxc/step_export.go
+++ b/builder/lxc/step_export.go
@@ -62,16 +62,20 @@ func (s *stepExport) Run(ctx context.Context, state multistep.StateBag) multiste
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
-	commands := make([][]string, 3)
-	commands[0] = []string{
-		"lxc-stop", "--name", name,
-	}
-	commands[1] = []string{
-		"tar", "-C", containerDir, "--numeric-owner", "--anchored", "--exclude=./rootfs/dev/log", "-czf", outputPath, "./rootfs",
-	}
-	commands[2] = []string{
-		"chmod", "+x", configFilePath,
-	}
+
+        commands := make([][]string, 4)
+        commands[0] = []string{
+                "lxc-stop", "--name", name,
+        }
+        commands[1] = []string{
+                "sudo", "setfacl", "-R", "-m", fmt.Sprintf("u:%s:rwx", user.Uid), filepath.Join(containerDir, "rootfs"),
+        }
+        commands[2] = []string{
+                "tar", "-C", containerDir, "--numeric-owner", "--anchored", "--exclude=./rootfs/dev/log", "-czf", outputPath, "./rootfs",
+        }
+        commands[3] = []string{
+                "chmod", "+x", configFilePath,
+        }
 
 	ui.Say("Exporting container...")
 	for _, command := range commands {


### PR DESCRIPTION
…tfs is being exported, it forces sudo to be used before tar gzipping the rootfs. Bear in mind to run "sudo su" before running the packer command as it needs the sudo to be cached

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-lxc/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. We recommend looking at existing tests as an example. 

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx

